### PR TITLE
Modernize quick guide HTML

### DIFF
--- a/esicont/srvc/html/CX5_QUICKGUIDE_EN.html
+++ b/esicont/srvc/html/CX5_QUICKGUIDE_EN.html
@@ -1,9 +1,19 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<title>CX5_QUICKGUIDE_JP</title>
+  <meta charset="utf-8">
+  <title>CX-5 Quick Guide</title>
+  <meta http-equiv="cache-control" content="no-cache, no-store, must-revalidate">
 </head>
-<body bgcolor="#cccccc">
-<iframe width="100%" height="100%" src="..\pdf\CX5_QUICKGUIDE_EN.pdf#page=1" marginheight="0" marginwidth="0" scrolling="auto">
+<body style="background:#cccccc; margin:0;">
+  <iframe
+    src="../pdf/CX5_QUICKGUIDE_EN.pdf#page=1"
+    width="100%"
+    height="100%"
+    frameborder="0"
+    marginheight="0"
+    marginwidth="0"
+    scrolling="auto"
+  ></iframe>
 </body>
 </html>

--- a/esicont/srvc/html/left_menu_S21.html
+++ b/esicont/srvc/html/left_menu_S21.html
@@ -1,12 +1,17 @@
-<HTML>
-	<HEAD>
-		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-		<META NAME="Robots" CONTENT="noindex">
-		<SCRIPT LANGUAGE="JScript" TYPE="text/javascript" SRC="../../esi_common/toc.js"></SCRIPT>
-		<LINK REL="stylesheet" TYPE="text/css" HREF="../../esi_common/toc_ie4.css" />
-	</HEAD>
-	<BODY text="#000000" bgcolor="#d3d3d3" leftMargin="0" topMargin="0" MARGINWIDTH="0" background="../../esi_common/images/left_bg.png" MARGINHEIGHT="0">
-		<NOBR>
-			<UL id="ulRoot" style="DISPLAY: block">
-<LI>	<IMG CLASS="clsNoHand"  width="10" height="12" SRC="../../esi_common/images/dc.png" />	<A TARGET="main" HREF="CX5_QUICKGUIDE_EN.html" NAME="CX5_QUICKGUIDE_EN" TITLE="คู่มือการใช้งานเบื้องต้น">คู่มือการใช้งานเบื้องต้น</A></LI>
-			<IFRAME name="hiddenframe" src="./blank.html" width="0" height="0"></IFRAME>	</BODY></HTML>
+<!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
+  <script type="text/javascript" src="../../esi_common/toc.js"></script>
+  <link rel="stylesheet" type="text/css" href="../../esi_common/toc_ie4.css" />
+</head>
+<body text="#000000" bgcolor="#d3d3d3" leftmargin="0" topmargin="0" marginwidth="0" marginheight="0" background="../../esi_common/images/left_bg.png">
+  <nobr>
+    <ul id="ulRoot" style="display: block">
+      <li><img class="clsNoHand" width="10" height="12" src="../../esi_common/images/dc.png" /> <a target="main" href="CX5_QUICKGUIDE_EN.html" name="CX5_QUICKGUIDE_EN" title="คู่มือการใช้งานเบื้องต้น">คู่มือการใช้งานเบื้องต้น</a></li>
+    </ul>
+    <iframe name="hiddenframe" src="./blank.html" width="0" height="0"></iframe>
+  </nobr>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- convert quick guide page to HTML5 and fix iframe path
- update quick guide menu to modern HTML5 markup

## Testing
- `npx htmlhint esicont/srvc/html/CX5_QUICKGUIDE_EN.html esicont/srvc/html/left_menu_S21.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_689aa53f77c0832db7200f30f1b81a98