### PR TITLE
Fix menu links so navigation stays within main layout

### DIFF
--- a/esicont/engine/A27/html/left_menu_A27.html
+++ b/esicont/engine/A27/html/left_menu_A27.html
@@ -8,6 +8,6 @@
 	<BODY text="#000000" bgcolor="#d3d3d3" leftMargin="0" topMargin="0" MARGINWIDTH="0" background="../../../esi_common/images/left_bg.png" MARGINHEIGHT="0">
 		<NOBR>
 			<UL id="ulRoot" style="DISPLAY: block">
-<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ข้อมูลทั่วไป" href="./node_A27_0000.html" target=fraToc>ข้อมูลทั่วไป</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="เครื่องยนต์" href="./node_A27_0002.html" target=fraToc>เครื่องยนต์</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ข้อมูลทั่วไป" href="./node_A27_0000.html" target="main">ข้อมูลทั่วไป</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="เครื่องยนต์" href="./node_A27_0002.html" target="main">เครื่องยนต์</A></LI><UL CLASS="hdn"></UL>
 			<IFRAME name="hiddenframe" src="./blank.html" width="0" height="0"></IFRAME>	</BODY></HTML>

--- a/esicont/engine/A31/html/left_menu_A31.html
+++ b/esicont/engine/A31/html/left_menu_A31.html
@@ -8,6 +8,6 @@
 	<BODY text="#000000" bgcolor="#d3d3d3" leftMargin="0" topMargin="0" MARGINWIDTH="0" background="../../../esi_common/images/left_bg.png" MARGINHEIGHT="0">
 		<NOBR>
 			<UL id="ulRoot" style="DISPLAY: block">
-<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ข้อมูลทั่วไป" href="./node_A31_0000.html" target=fraToc>ข้อมูลทั่วไป</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="เครื่องยนต์" href="./node_A31_0002.html" target=fraToc>เครื่องยนต์</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ข้อมูลทั่วไป" href="./node_A31_0000.html" target="main">ข้อมูลทั่วไป</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="เครื่องยนต์" href="./node_A31_0002.html" target="main">เครื่องยนต์</A></LI><UL CLASS="hdn"></UL>
 			<IFRAME name="hiddenframe" src="./blank.html" width="0" height="0"></IFRAME>	</BODY></HTML>

--- a/esicont/mission/B38/html/left_menu_B38.html
+++ b/esicont/mission/B38/html/left_menu_B38.html
@@ -8,7 +8,7 @@
 	<BODY text="#000000" bgcolor="#d3d3d3" leftMargin="0" topMargin="0" MARGINWIDTH="0" background="../../../esi_common/images/left_bg.png" MARGINHEIGHT="0">
 		<NOBR>
 			<UL id="ulRoot" style="DISPLAY: block">
-<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ข้อมูลทั่วไป" href="./node_B38_0000.html" target=fraToc>ข้อมูลทั่วไป</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบส่งกำลัง/เพลา" href="./node_B38_0002.html" target=fraToc>ระบบส่งกำลัง/เพลา</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ชุดส่งกำลัง/ชุดเกียร์" href="./node_B38_0006.html" target=fraToc>ชุดส่งกำลัง/ชุดเกียร์</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ข้อมูลทั่วไป" href="./node_B38_0000.html" target="main">ข้อมูลทั่วไป</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบส่งกำลัง/เพลา" href="./node_B38_0002.html" target="main">ระบบส่งกำลัง/เพลา</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ชุดส่งกำลัง/ชุดเกียร์" href="./node_B38_0006.html" target="main">ชุดส่งกำลัง/ชุดเกียร์</A></LI><UL CLASS="hdn"></UL>
 			<IFRAME name="hiddenframe" src="./blank.html" width="0" height="0"></IFRAME>	</BODY></HTML>

--- a/esicont/mission/B42/html/left_menu_B42.html
+++ b/esicont/mission/B42/html/left_menu_B42.html
@@ -8,7 +8,7 @@
 	<BODY text="#000000" bgcolor="#d3d3d3" leftMargin="0" topMargin="0" MARGINWIDTH="0" background="../../../esi_common/images/left_bg.png" MARGINHEIGHT="0">
 		<NOBR>
 			<UL id="ulRoot" style="DISPLAY: block">
-<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ข้อมูลทั่วไป" href="./node_B42_0000.html" target=fraToc>ข้อมูลทั่วไป</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบส่งกำลัง/เพลา" href="./node_B42_0002.html" target=fraToc>ระบบส่งกำลัง/เพลา</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ชุดส่งกำลัง/ชุดเกียร์" href="./node_B42_0006.html" target=fraToc>ชุดส่งกำลัง/ชุดเกียร์</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ข้อมูลทั่วไป" href="./node_B42_0000.html" target="main">ข้อมูลทั่วไป</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบส่งกำลัง/เพลา" href="./node_B42_0002.html" target="main">ระบบส่งกำลัง/เพลา</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ชุดส่งกำลัง/ชุดเกียร์" href="./node_B42_0006.html" target="main">ชุดส่งกำลัง/ชุดเกียร์</A></LI><UL CLASS="hdn"></UL>
 			<IFRAME name="hiddenframe" src="./blank.html" width="0" height="0"></IFRAME>	</BODY></HTML>

--- a/esicont/mission/B43/html/left_menu_B43.html
+++ b/esicont/mission/B43/html/left_menu_B43.html
@@ -8,7 +8,7 @@
 	<BODY text="#000000" bgcolor="#d3d3d3" leftMargin="0" topMargin="0" MARGINWIDTH="0" background="../../../esi_common/images/left_bg.png" MARGINHEIGHT="0">
 		<NOBR>
 			<UL id="ulRoot" style="DISPLAY: block">
-<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ข้อมูลทั่วไป" href="./node_B43_0000.html" target=fraToc>ข้อมูลทั่วไป</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบส่งกำลัง/เพลา" href="./node_B43_0002.html" target=fraToc>ระบบส่งกำลัง/เพลา</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ชุดส่งกำลัง/ชุดเกียร์" href="./node_B43_0006.html" target=fraToc>ชุดส่งกำลัง/ชุดเกียร์</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ข้อมูลทั่วไป" href="./node_B43_0000.html" target="main">ข้อมูลทั่วไป</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบส่งกำลัง/เพลา" href="./node_B43_0002.html" target="main">ระบบส่งกำลัง/เพลา</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ชุดส่งกำลัง/ชุดเกียร์" href="./node_B43_0006.html" target="main">ชุดส่งกำลัง/ชุดเกียร์</A></LI><UL CLASS="hdn"></UL>
 			<IFRAME name="hiddenframe" src="./blank.html" width="0" height="0"></IFRAME>	</BODY></HTML>

--- a/esicont/mission/B44/html/left_menu_B44.html
+++ b/esicont/mission/B44/html/left_menu_B44.html
@@ -8,7 +8,7 @@
 	<BODY text="#000000" bgcolor="#d3d3d3" leftMargin="0" topMargin="0" MARGINWIDTH="0" background="../../../esi_common/images/left_bg.png" MARGINHEIGHT="0">
 		<NOBR>
 			<UL id="ulRoot" style="DISPLAY: block">
-<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ข้อมูลทั่วไป" href="./node_B44_0000.html" target=fraToc>ข้อมูลทั่วไป</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบส่งกำลัง/เพลา" href="./node_B44_0002.html" target=fraToc>ระบบส่งกำลัง/เพลา</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ชุดส่งกำลัง/ชุดเกียร์" href="./node_B44_0006.html" target=fraToc>ชุดส่งกำลัง/ชุดเกียร์</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ข้อมูลทั่วไป" href="./node_B44_0000.html" target="main">ข้อมูลทั่วไป</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบส่งกำลัง/เพลา" href="./node_B44_0002.html" target="main">ระบบส่งกำลัง/เพลา</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ชุดส่งกำลัง/ชุดเกียร์" href="./node_B44_0006.html" target="main">ชุดส่งกำลัง/ชุดเกียร์</A></LI><UL CLASS="hdn"></UL>
 			<IFRAME name="hiddenframe" src="./blank.html" width="0" height="0"></IFRAME>	</BODY></HTML>

--- a/esicont/srvc/html/left_menu_S01.html
+++ b/esicont/srvc/html/left_menu_S01.html
@@ -8,19 +8,19 @@
 	<BODY text="#000000" bgcolor="#d3d3d3" leftMargin="0" topMargin="0" MARGINWIDTH="0" background="../../esi_common/images/left_bg.png" MARGINHEIGHT="0">
 		<NOBR>
 			<UL id="ulRoot" style="DISPLAY: block">
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ข้อมูลทั่วไป" href="./node_S01_0000.html" target=fraToc>ข้อมูลทั่วไป</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="เครื่องยนต์" href="./node_S01_0002.html" target=fraToc>เครื่องยนต์</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบรองรับ" href="./node_S01_0034.html" target=fraToc>ระบบรองรับ</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบส่งกำลัง/เพลา" href="./node_S01_0044.html" target=fraToc>ระบบส่งกำลัง/เพลา</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="เบรก" href="./node_S01_0058.html" target=fraToc>เบรก</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ชุดส่งกำลัง/ชุดเกียร์" href="./node_S01_0068.html" target=fraToc>ชุดส่งกำลัง/ชุดเกียร์</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบพวงมาลัย" href="./node_S01_0084.html" target=fraToc>ระบบพวงมาลัย</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ฮีทเตอร์ การระบายอากาศและระบบปรับอากาศ (HVAC)" href="./node_S01_0091.html" target=fraToc>ฮีทเตอร์ การระบายอากาศและระบบปรับอากาศ (HVAC)</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบความปลอดภัย" href="./node_S01_0100.html" target=fraToc>ระบบความปลอดภัย</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ตัวถังและอุปกรณ์เสริม" href="./node_S01_0106.html" target=fraToc>ตัวถังและอุปกรณ์เสริม</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบการสื่อสารแบบมัลติเพล็กซ์" href="./node_S01_0149.html" target=fraToc>ระบบการสื่อสารแบบมัลติเพล็กซ์</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบ i-stop" href="./node_S01_0154.html" target=fraToc>ระบบ i-stop</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="คุณสมบัติการกำหนดส่วนบุคคล" href="./node_S01_0157.html" target=fraToc>คุณสมบัติการกำหนดส่วนบุคคล</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ข้อมูลทั่วไป" href="./node_S01_0000.html" target="main">ข้อมูลทั่วไป</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="เครื่องยนต์" href="./node_S01_0002.html" target="main">เครื่องยนต์</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบรองรับ" href="./node_S01_0034.html" target="main">ระบบรองรับ</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบส่งกำลัง/เพลา" href="./node_S01_0044.html" target="main">ระบบส่งกำลัง/เพลา</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="เบรก" href="./node_S01_0058.html" target="main">เบรก</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ชุดส่งกำลัง/ชุดเกียร์" href="./node_S01_0068.html" target="main">ชุดส่งกำลัง/ชุดเกียร์</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบพวงมาลัย" href="./node_S01_0084.html" target="main">ระบบพวงมาลัย</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ฮีทเตอร์ การระบายอากาศและระบบปรับอากาศ (HVAC)" href="./node_S01_0091.html" target="main">ฮีทเตอร์ การระบายอากาศและระบบปรับอากาศ (HVAC)</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบความปลอดภัย" href="./node_S01_0100.html" target="main">ระบบความปลอดภัย</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ตัวถังและอุปกรณ์เสริม" href="./node_S01_0106.html" target="main">ตัวถังและอุปกรณ์เสริม</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบการสื่อสารแบบมัลติเพล็กซ์" href="./node_S01_0149.html" target="main">ระบบการสื่อสารแบบมัลติเพล็กซ์</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบ i-stop" href="./node_S01_0154.html" target="main">ระบบ i-stop</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="คุณสมบัติการกำหนดส่วนบุคคล" href="./node_S01_0157.html" target="main">คุณสมบัติการกำหนดส่วนบุคคล</A></LI><UL CLASS="hdn"></UL>
 <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><hr>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="OASIS" href="./node_S01_0159.html" target=fraToc>OASIS</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="OASIS" href="./node_S01_0159.html" target="main">OASIS</A></LI><UL CLASS="hdn"></UL>
 			<IFRAME name="hiddenframe" src="./blank.html" width="0" height="0"></IFRAME>	</BODY></HTML>

--- a/esicont/srvc/html/left_menu_S02.html
+++ b/esicont/srvc/html/left_menu_S02.html
@@ -8,16 +8,16 @@
 	<BODY text="#000000" bgcolor="#d3d3d3" leftMargin="0" topMargin="0" MARGINWIDTH="0" background="../../esi_common/images/left_bg.png" MARGINHEIGHT="0">
 		<NOBR>
 			<UL id="ulRoot" style="DISPLAY: block">
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ข้อมูลทั่วไป" href="./node_S02_0000.html" target=fraToc>ข้อมูลทั่วไป</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="เครื่องยนต์" href="./node_S02_0002.html" target=fraToc>เครื่องยนต์</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบรองรับ" href="./node_S02_0029.html" target=fraToc>ระบบรองรับ</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบส่งกำลัง/เพลา" href="./node_S02_0035.html" target=fraToc>ระบบส่งกำลัง/เพลา</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="เบรก" href="./node_S02_0044.html" target=fraToc>เบรก</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ชุดส่งกำลัง/ชุดเกียร์" href="./node_S02_0051.html" target=fraToc>ชุดส่งกำลัง/ชุดเกียร์</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบพวงมาลัย" href="./node_S02_0064.html" target=fraToc>ระบบพวงมาลัย</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ฮีทเตอร์ การระบายอากาศและระบบปรับอากาศ (HVAC)" href="./node_S02_0068.html" target=fraToc>ฮีทเตอร์ การระบายอากาศและระบบปรับอากาศ (HVAC)</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบความปลอดภัย" href="./node_S02_0074.html" target=fraToc>ระบบความปลอดภัย</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ตัวถังและอุปกรณ์เสริม" href="./node_S02_0079.html" target=fraToc>ตัวถังและอุปกรณ์เสริม</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบการสื่อสารแบบมัลติเพล็กซ์" href="./node_S02_0095.html" target=fraToc>ระบบการสื่อสารแบบมัลติเพล็กซ์</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบ i-stop" href="./node_S02_0099.html" target=fraToc>ระบบ i-stop</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ข้อมูลทั่วไป" href="./node_S02_0000.html" target="main">ข้อมูลทั่วไป</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="เครื่องยนต์" href="./node_S02_0002.html" target="main">เครื่องยนต์</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบรองรับ" href="./node_S02_0029.html" target="main">ระบบรองรับ</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบส่งกำลัง/เพลา" href="./node_S02_0035.html" target="main">ระบบส่งกำลัง/เพลา</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="เบรก" href="./node_S02_0044.html" target="main">เบรก</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ชุดส่งกำลัง/ชุดเกียร์" href="./node_S02_0051.html" target="main">ชุดส่งกำลัง/ชุดเกียร์</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบพวงมาลัย" href="./node_S02_0064.html" target="main">ระบบพวงมาลัย</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ฮีทเตอร์ การระบายอากาศและระบบปรับอากาศ (HVAC)" href="./node_S02_0068.html" target="main">ฮีทเตอร์ การระบายอากาศและระบบปรับอากาศ (HVAC)</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบความปลอดภัย" href="./node_S02_0074.html" target="main">ระบบความปลอดภัย</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ตัวถังและอุปกรณ์เสริม" href="./node_S02_0079.html" target="main">ตัวถังและอุปกรณ์เสริม</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบการสื่อสารแบบมัลติเพล็กซ์" href="./node_S02_0095.html" target="main">ระบบการสื่อสารแบบมัลติเพล็กซ์</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบ i-stop" href="./node_S02_0099.html" target="main">ระบบ i-stop</A></LI><UL CLASS="hdn"></UL>
 			<IFRAME name="hiddenframe" src="./blank.html" width="0" height="0"></IFRAME>	</BODY></HTML>

--- a/esicont/srvc/html/left_menu_S04.html
+++ b/esicont/srvc/html/left_menu_S04.html
@@ -8,24 +8,24 @@
 	<BODY text="#000000" bgcolor="#d3d3d3" leftMargin="0" topMargin="0" MARGINWIDTH="0" background="../../esi_common/images/left_bg.png" MARGINHEIGHT="0">
 		<NOBR>
 			<UL id="ulRoot" style="DISPLAY: block">
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ข้อมูลทั่วไป" href="./node_S04_0000.html" target=fraToc>ข้อมูลทั่วไป</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="จุดการตรวจสอบตามรหัสวิเคราะห์ปัญหานั้นๆ" href="./node_S04_0003.html" target=fraToc>จุดการตรวจสอบตามรหัสวิเคราะห์ปัญหานั้นๆ</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ข้อมูลทั่วไป" href="./node_S04_0000.html" target="main">ข้อมูลทั่วไป</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="จุดการตรวจสอบตามรหัสวิเคราะห์ปัญหานั้นๆ" href="./node_S04_0003.html" target="main">จุดการตรวจสอบตามรหัสวิเคราะห์ปัญหานั้นๆ</A></LI><UL CLASS="hdn"></UL>
 <br><br> <Font Color="#0000FF">เมนูผังวงจรระบบ</Font>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="เครื่องยนต์" href="./node_S04_0016.html" target=fraToc>เครื่องยนต์</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบส่งกำลัง/เพลา" href="./node_S04_0023.html" target=fraToc>ระบบส่งกำลัง/เพลา</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="เบรก" href="./node_S04_0025.html" target=fraToc>เบรก</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ชุดส่งกำลัง/ชุดเกียร์" href="./node_S04_0027.html" target=fraToc>ชุดส่งกำลัง/ชุดเกียร์</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบพวงมาลัย" href="./node_S04_0030.html" target=fraToc>ระบบพวงมาลัย</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ฮีทเตอร์ การระบายอากาศและระบบปรับอากาศ (HVAC)" href="./node_S04_0032.html" target=fraToc>ฮีทเตอร์ การระบายอากาศและระบบปรับอากาศ (HVAC)</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบความปลอดภัย" href="./node_S04_0034.html" target=fraToc>ระบบความปลอดภัย</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ตัวถังและอุปกรณ์เสริม" href="./node_S04_0036.html" target=fraToc>ตัวถังและอุปกรณ์เสริม</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ขั้วต่อเชื่อมโยงข้อมูล" href="./node_S04_0047.html" target=fraToc>ขั้วต่อเชื่อมโยงข้อมูล</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="เครื่องยนต์" href="./node_S04_0016.html" target="main">เครื่องยนต์</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบส่งกำลัง/เพลา" href="./node_S04_0023.html" target="main">ระบบส่งกำลัง/เพลา</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="เบรก" href="./node_S04_0025.html" target="main">เบรก</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ชุดส่งกำลัง/ชุดเกียร์" href="./node_S04_0027.html" target="main">ชุดส่งกำลัง/ชุดเกียร์</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบพวงมาลัย" href="./node_S04_0030.html" target="main">ระบบพวงมาลัย</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ฮีทเตอร์ การระบายอากาศและระบบปรับอากาศ (HVAC)" href="./node_S04_0032.html" target="main">ฮีทเตอร์ การระบายอากาศและระบบปรับอากาศ (HVAC)</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบความปลอดภัย" href="./node_S04_0034.html" target="main">ระบบความปลอดภัย</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ตัวถังและอุปกรณ์เสริม" href="./node_S04_0036.html" target="main">ตัวถังและอุปกรณ์เสริม</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ขั้วต่อเชื่อมโยงข้อมูล" href="./node_S04_0047.html" target="main">ขั้วต่อเชื่อมโยงข้อมูล</A></LI><UL CLASS="hdn"></UL>
 <br><br> <Font Color="#0000FF">เมนูนอกเหนือจากเมนูแผนผังวงจรระบบ</Font>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ผังวงจรไฟฟ้า" href="./node_S04_0049.html" target=fraToc>ผังวงจรไฟฟ้า</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="รายการจุดต่อลงกราวด์" href="./node_S04_0050.html" target=fraToc>รายการจุดต่อลงกราวด์</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ตำแหน่งขั้วต่อ / จุดต่อลงกราวด์" href="./node_S04_0051.html" target=fraToc>ตำแหน่งขั้วต่อ / จุดต่อลงกราวด์</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="กล่องฟิวส์" href="./node_S04_0052.html" target=fraToc>กล่องฟิวส์</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="การค้นหาผังวงจรระบบตามสีชุดสายไฟ" href="./node_S04_0053.html" target=fraToc>การค้นหาผังวงจรระบบตามสีชุดสายไฟ</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ผังวงจรไฟฟ้า" href="./node_S04_0049.html" target="main">ผังวงจรไฟฟ้า</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="รายการจุดต่อลงกราวด์" href="./node_S04_0050.html" target="main">รายการจุดต่อลงกราวด์</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ตำแหน่งขั้วต่อ / จุดต่อลงกราวด์" href="./node_S04_0051.html" target="main">ตำแหน่งขั้วต่อ / จุดต่อลงกราวด์</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="กล่องฟิวส์" href="./node_S04_0052.html" target="main">กล่องฟิวส์</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="การค้นหาผังวงจรระบบตามสีชุดสายไฟ" href="./node_S04_0053.html" target="main">การค้นหาผังวงจรระบบตามสีชุดสายไฟ</A></LI><UL CLASS="hdn"></UL>
 <br><br> <Font Color="#0000FF">ดัชนี</Font>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ดัชนีตัวอักษร" href="./node_S04_0468.html" target=fraToc>ดัชนีตัวอักษร</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ดัชนีตัวอักษร" href="./node_S04_0468.html" target="main">ดัชนีตัวอักษร</A></LI><UL CLASS="hdn"></UL>
 			<IFRAME name="hiddenframe" src="./blank.html" width="0" height="0"></IFRAME>	</BODY></HTML>

--- a/esicont/srvc/html/left_menu_S05.html
+++ b/esicont/srvc/html/left_menu_S05.html
@@ -8,6 +8,6 @@
 	<BODY text="#000000" bgcolor="#d3d3d3" leftMargin="0" topMargin="0" MARGINWIDTH="0" background="../../esi_common/images/left_bg.png" MARGINHEIGHT="0">
 		<NOBR>
 			<UL id="ulRoot" style="DISPLAY: block">
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ข้อมูลทั่วไป" href="./node_S05_0000.html" target=fraToc>ข้อมูลทั่วไป</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ตัวถังและอุปกรณ์เสริม" href="./node_S05_0002.html" target=fraToc>ตัวถังและอุปกรณ์เสริม</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ข้อมูลทั่วไป" href="./node_S05_0000.html" target="main">ข้อมูลทั่วไป</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ตัวถังและอุปกรณ์เสริม" href="./node_S05_0002.html" target="main">ตัวถังและอุปกรณ์เสริม</A></LI><UL CLASS="hdn"></UL>
 			<IFRAME name="hiddenframe" src="./blank.html" width="0" height="0"></IFRAME>	</BODY></HTML>

--- a/esicont/srvc/html/left_menu_S08.html
+++ b/esicont/srvc/html/left_menu_S08.html
@@ -8,12 +8,12 @@
 	<BODY text="#000000" bgcolor="#d3d3d3" leftMargin="0" topMargin="0" MARGINWIDTH="0" background="../../esi_common/images/left_bg.png" MARGINHEIGHT="0">
 		<NOBR>
 			<UL id="ulRoot" style="DISPLAY: block">
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="เครื่องยนต์" href="./node_S08_0000.html" target=fraToc>เครื่องยนต์</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบรองรับ" href="./node_S08_0001.html" target=fraToc>ระบบรองรับ</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบส่งกำลัง/เพลา" href="./node_S08_0002.html" target=fraToc>ระบบส่งกำลัง/เพลา</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="เบรก" href="./node_S08_0003.html" target=fraToc>เบรก</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ชุดส่งกำลัง/ชุดเกียร์" href="./node_S08_0004.html" target=fraToc>ชุดส่งกำลัง/ชุดเกียร์</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบพวงมาลัย" href="./node_S08_0005.html" target=fraToc>ระบบพวงมาลัย</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ฮีทเตอร์ การระบายอากาศและระบบปรับอากาศ (HVAC)" href="./node_S08_0006.html" target=fraToc>ฮีทเตอร์ การระบายอากาศและระบบปรับอากาศ (HVAC)</A></LI><UL CLASS="hdn"></UL>
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ตัวถังและอุปกรณ์เสริม" href="./node_S08_0007.html" target=fraToc>ตัวถังและอุปกรณ์เสริม</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="เครื่องยนต์" href="./node_S08_0000.html" target="main">เครื่องยนต์</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบรองรับ" href="./node_S08_0001.html" target="main">ระบบรองรับ</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบส่งกำลัง/เพลา" href="./node_S08_0002.html" target="main">ระบบส่งกำลัง/เพลา</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="เบรก" href="./node_S08_0003.html" target="main">เบรก</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ชุดส่งกำลัง/ชุดเกียร์" href="./node_S08_0004.html" target="main">ชุดส่งกำลัง/ชุดเกียร์</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ระบบพวงมาลัย" href="./node_S08_0005.html" target="main">ระบบพวงมาลัย</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ฮีทเตอร์ การระบายอากาศและระบบปรับอากาศ (HVAC)" href="./node_S08_0006.html" target="main">ฮีทเตอร์ การระบายอากาศและระบบปรับอากาศ (HVAC)</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="ตัวถังและอุปกรณ์เสริม" href="./node_S08_0007.html" target="main">ตัวถังและอุปกรณ์เสริม</A></LI><UL CLASS="hdn"></UL>
 			<IFRAME name="hiddenframe" src="./blank.html" width="0" height="0"></IFRAME>	</BODY></HTML>

--- a/esicont/srvc/html/left_menu_S20.html
+++ b/esicont/srvc/html/left_menu_S20.html
@@ -8,5 +8,5 @@
 	<BODY text="#000000" bgcolor="#d3d3d3" leftMargin="0" topMargin="0" MARGINWIDTH="0" background="../../esi_common/images/left_bg.png" MARGINHEIGHT="0">
 		<NOBR>
 			<UL id="ulRoot" style="DISPLAY: block">
-<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="การดูแลและการบำรุงรักษา" href="./node_S20_0000.html" target=fraToc>การดูแลและการบำรุงรักษา</A></LI><UL CLASS="hdn"></UL>
+<LI class="kid">	<IMG src="../../esi_common/images/plus2.png"  width="11" height="11">	<A title="การดูแลและการบำรุงรักษา" href="./node_S20_0000.html" target="main">การดูแลและการบำรุงรักษา</A></LI><UL CLASS="hdn"></UL>
 			<IFRAME name="hiddenframe" src="./blank.html" width="0" height="0"></IFRAME>	</BODY></HTML>


### PR DESCRIPTION
## Summary
- Update left menu hyperlinks to target the main content frame rather than an undefined frame
- Prevent menu clicks from navigating away before content loads in the right pane

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689aaca0b26c832dad5fcf506f8f5730